### PR TITLE
CI: `apt-get update` before `apt-get install gnome-keyring`

### DIFF
--- a/.github/workflows/test_vectors.yml
+++ b/.github/workflows/test_vectors.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install gnome-keyring
-        run: sudo apt-get install gnome-keyring
+        run: sudo apt-get update; sudo apt-get install gnome-keyring
 
       - name: Install poetry
         run: pip install --user poetry

--- a/.github/workflows/test_vectors.yml
+++ b/.github/workflows/test_vectors.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install gnome-keyring
-        run: sudo apt-get update; sudo apt-get install gnome-keyring
+        run: sudo apt-get update && sudo apt-get install -y gnome-keyring
 
       - name: Install poetry
         run: pip install --user poetry


### PR DESCRIPTION
This PR is intended to fix the mirror+file 404s that started [showing up in CI](https://github.com/zcash/zcash-test-vectors/actions/runs/17371436288/job/49407384424#step:3:94).

`apt-get update` seemed the simplest place to start. Open to other ideas!